### PR TITLE
fix heroku redirect uri

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,8 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'],
+      {
+        redirect_uri: ENV['APP_URL'] + "/oauth/callback",
+        prompt: 'consent',
+        scope: 'userinfo.email, userinfo.profile'
+      }
+end


### PR DESCRIPTION
Google Cloud ConsoleでのリダイレクトURIの設定変更
https://maifuru-4b2761864ae8.herokuapp.com/oauth/callback

heroku/Config Vars
googleシークレットキー追加